### PR TITLE
Accept BLP1 picture type 6 (WoW JPEG variant)

### DIFF
--- a/src/Codec/Picture/Blp/Internal/Parser.hs
+++ b/src/Codec/Picture/Blp/Internal/Parser.hs
@@ -84,6 +84,13 @@ pictureTypeParser = (<?> "picture type") $ do
     3 -> return UncompressedWithAlpha
     4 -> return UncompressedWithAlpha
     5 -> return UncompressedWithoutAlpha
+    -- BLP1 files seen in the wild (notably from World of Warcraft assets,
+    -- as well as some BLPs found inside Warcraft III maps) use picture type
+    -- 6 for JPEG-compressed textures with an alpha channel. The actual data
+    -- layout is identical to type 2, and the dispatch in `blpParser` already
+    -- decides JPEG vs uncompressed based on the `compression` field, so we
+    -- can safely treat 6 as another spelling of `JPEGType`.
+    6 -> return JPEGType
     _ -> fail $ "Unknown picture type " ++ show i
 
 blpJpegParser :: [(Word32, Word32)] -> Parser BlpExt


### PR DESCRIPTION
Closes #4.

## What this fixes

BLP1 files seen in the wild — most prominently World of Warcraft assets, and the many BLPs ripped from WoW into custom Warcraft III maps — use **picture type 6** to mark JPEG-compressed textures with an alpha channel. The current parser rejects them with:

```
parse error: picture type: Failed reading: Unknown picture type 6
```

I tested 51 such files (button icons, armour textures, building parts, etc.) and confirmed they all share:

- `compression = 0` (`BlpCompressionJPEG`)
- `flags = 8` (alpha channel)
- `pictureType = 6`
- normal JPEG header + mipmap layout (e.g. JPEG header bytes start with `ff d8 ff db` right after the 4-byte header-size dword)

The data layout is byte-for-byte identical to a standard `pictureType = 2` JPEG BLP1.

## The fix

`blpParser` already dispatches to `blpJpegParser` vs the uncompressed parsers purely on the `compression` field — it doesn't actually look at `pictureType` for the JPEG branch. The only thing in the way is `pictureTypeParser`, which `fail`s on unknown values.

I add `6 -> return JPEGType` to that case expression. Mapping to the existing `JPEGType` constructor (rather than introducing a new one) keeps the fix self-contained: no ripple into `Convert.hs`, `Encoder.hs`, `Statistics.hs`, or `Data.hs`.

## Verification

```
$ stack exec blp2any -- convert samples/picture6 /tmp/out -f png -p
... (51 of 51 files)
Success
```

Before this PR, all 51 failed with the "Unknown picture type 6" error. After, every file decodes and the resulting PNGs visually match the source textures (spot-checked: `dhf_eyes.png`, `war_t63.png`, `sylvanasbanshee_cloth.png`).

Existing files (`pictureType` 2-5) are completely unaffected — only one new case arm is added.

## Out of scope

I deliberately didn't relax `pictureTypeParser` to accept arbitrary `Word32` values, or add a new `JPEGTypeAlt` constructor — happy to do either if you'd prefer a different shape.