### PR TITLE
Tolerate BLP1 files with short (variable-length) palettes

### DIFF
--- a/src/Codec/Picture/Blp/Internal/Parser.hs
+++ b/src/Codec/Picture/Blp/Internal/Parser.hs
@@ -105,9 +105,27 @@ skipToOffset i = do
   if diff <= 0 then return ()
     else void $ AT.take diff
 
+-- | Read up to 256 palette entries, bounded by the offset of the first
+-- mipmap. Some BLP1 files in the wild (e.g. produced by community map
+-- tools) only emit the palette entries that are actually used, so the
+-- palette region between the main header and the first mipmap can be
+-- shorter than the canonical 1024 bytes. We pad the resulting vector to
+-- 256 entries with transparent black so the rest of the codebase, which
+-- indexes the palette by an arbitrary `Word8`, stays sound.
+paletteParser :: [(Word32, Word32)] -> Parser (V.Vector PixelRGBA8)
+paletteParser mps = do
+  pos <- getPos
+  let firstOffset = case mps of
+        ((o, _):_) -> fromIntegral o
+        []         -> pos + 1024  -- no mipmaps: keep historical behaviour
+      available   = max 0 (firstOffset - pos)
+      nEntries    = min 256 (available `div` 4)
+  entries <- V.replicateM nEntries rgba8
+  return $ entries V.++ V.replicate (256 - nEntries) (PixelRGBA8 0 0 0 0)
+
 blpUncompressed1Parser :: [(Word32, Word32)] -> Parser BlpExt
 blpUncompressed1Parser mps = do
-  blpU1Palette <- V.replicateM 256 rgba8
+  blpU1Palette <- paletteParser mps
   blpU1MipMaps <- forM mps $ \(offset, size) -> do
     skipToOffset offset
     let halfSize = fromIntegral size `div` 2
@@ -118,7 +136,7 @@ blpUncompressed1Parser mps = do
 
 blpUncompressed2Parser :: [(Word32, Word32)] -> Parser BlpExt
 blpUncompressed2Parser mps = do
-  blpU2Palette <- V.replicateM 256 rgba8
+  blpU2Palette <- paletteParser mps
   blpU2MipMaps <- forM mps $ \(offset, size) -> do
     skipToOffset offset
     AT.take (fromIntegral size) <?> "index list"


### PR DESCRIPTION
## What this fixes

Some BLP1 files in the wild — including ones produced by various
Warcraft III community map tools — only emit the palette entries that
are actually used by the texture, so the palette region between the
156-byte main header and the first mipmap is shorter than the canonical
1024 bytes. The current parser hard-codes a 256-entry read, walks past
the first mipmap offset, and then fails when it tries to read the
mipmap data:

\`\`\`
parse error: index list: not enough input
\`\`\`

I have 18 such samples (all 64×64 button icons of the form \`btn*.blp\`)
that share the same shape:

| field                | value                                |
|----------------------|--------------------------------------|
| \`compression\`        | 1 (\`BlpCompressionUncompressed\`)     |
| \`pictureType\`        | 5 (\`UncompressedWithoutAlpha\`)       |
| width × height       | 64 × 64                              |
| \`mipMapOffsets[0]\`   | 540 (typical) — palette is only 384B |
| \`mipMapSizes[0]\`     | 4096 (= 64×64, one byte per pixel)   |
| file size            | 4636 = 540 + 4096                    |

So the palette is exactly 96 entries instead of 256. Mipmap data is
correctly sized for the dimensions and the alpha bytes look like a
normal BLP palette (always 0x00) — these are real, intentional files,
not corruption.

## The fix

I introduce a small \`paletteParser\` helper that:

* Computes the available palette region as
  \`firstMipmapOffset - currentParserPosition\` using the existing
  \`getPos\` primitive.
* Reads up to **256** entries (capped, so larger-than-canonical
  palettes are still safe — \`skipToOffset\` jumps past any extra bytes).
* **Pads** the resulting vector back up to 256 entries with
  \`PixelRGBA8 0 0 0 0\`, so the rest of the codebase, which indexes
  the palette by an arbitrary \`Word8\`, stays sound.

Both \`blpUncompressed1Parser\` and \`blpUncompressed2Parser\` now use
this helper. (Only the \`U2\` path was exercised by my samples, but the
hardcoded 256 read was the same bug class on both.)

### Why this is safe for spec-conforming files

For a normal BLP1 file the first mipmap offset is \`156 + 1024 = 1180\`,
so \`available == 1024\`, \`nEntries == 256\`, and the \`V.replicate\` pad
collapses to \`V.empty\`. Behaviour is byte-for-byte identical to the
old parser. For the \`mps == []\` corner case (a file with zero
mipmaps, which \`decodeBlp\` already errors on downstream) the fallback
keeps the historical full-256 read.

## Verification

\`\`\`
$ stack exec blp2any -- convert samples/endoffile /tmp/out -f png -p
... (18 of 18 files)
Success
\`\`\`

Before this PR, all 18 failed with the \`not enough input\` error.
After, every file decodes and the resulting PNGs look like the
expected button icons (spot-checked: \`btn1bronza.png\`,
\`btnkakuzue.png\`).

## Out of scope

* Encoder side — \`encodeBlp\` always writes 256-entry palettes, which
  is spec-compliant. Round-trips through \`blp2any convert\` therefore
  produce canonical 1024-byte-palette output, which is fine.
* Adding a Haskell test suite — the project doesn't have one today and
  I didn't want to introduce one as part of a bug fix.