### PR TITLE
Skip mipmap slots that point past end of file

### DIFF
--- a/src/Codec/Picture/Blp/Internal/Parser.hs
+++ b/src/Codec/Picture/Blp/Internal/Parser.hs
@@ -18,7 +18,7 @@ import Control.Monad
 import Data.Attoparsec.ByteString as AT
 import Data.Bits
 import Data.ByteString (ByteString)
-import Data.List (nub)
+import Data.List (nub, sortOn)
 import Data.Word
 
 import qualified Data.Vector as V
@@ -27,8 +27,8 @@ import qualified Data.ByteString as BS
 
 import Codec.Picture.Blp.Internal.Data
 
-blpParser :: Parser BlpStruct
-blpParser = do
+blpParser :: Int -> Parser BlpStruct
+blpParser inputLen = do
   _ <- blpVersion
   blpCompression <- compressionParser
   blpFlags <- flagsParser
@@ -38,7 +38,16 @@ blpParser = do
   blpPictureSubType <- dword <?> "picture subtype"
   blpMipMapOffset <- replicateM 16 dword <?> "mipmaps offsets"
   blpMipMapSize <- replicateM 16 dword <?> "mipmaps sizes"
-  let mipMapsInfo = nub . filter ((> 0) . snd) $ blpMipMapOffset `zip` blpMipMapSize
+  -- BLP1 specifies 16 mipmap slots but most files only use a handful; the
+  -- unused slots should be zero but some real-world files contain garbage
+  -- offsets/sizes left behind by the writing tool. Drop any slot whose
+  -- advertised range would run past the end of the file, then sort the
+  -- survivors by offset so that the monotonic `skipToOffset` walks forward
+  -- correctly even if the file stored mipmaps out of order.
+  let rawMipMapsInfo = nub . filter ((> 0) . snd) $ blpMipMapOffset `zip` blpMipMapSize
+      fitsInput (o, s) =
+        fromIntegral o + fromIntegral s <= (fromIntegral inputLen :: Integer)
+      mipMapsInfo = sortOn fst $ filter fitsInput rawMipMapsInfo
   blpExt <- case blpCompression of
     BlpCompressionJPEG -> blpJpegParser mipMapsInfo
     BlpCompressionUncompressed -> case blpPictureType of
@@ -125,4 +134,4 @@ blpUncompressed2Parser mps = do
   return $ BlpUncompressed2 {..}
 
 parseBlp :: ByteString -> Either String BlpStruct
-parseBlp = parseOnly blpParser
+parseBlp bs = parseOnly (blpParser (BS.length bs)) bs


### PR DESCRIPTION
## What this fixes

BLP1 reserves 16 mipmap slots per file but most files only use a handful; the unused slots should be zero but some real-world files contain garbage offsets/sizes left behind by the writing tool. When the garbage has a non-zero `size`, the current parser tries to `AT.take` that many bytes from past the end of input and the whole parse fails with:

```
parse error: not enough bytes
```

I have 13 such samples (Blizzard-shipped WoW textures and Warcraft III map assets) that all look structurally valid up to mipmap 9, followed by a slot like `(offset=0x4276, size=0)` or similar garbage.

## What the change does

- Thread the input byte length into `blpParser` and `parseBlp`.
- After the usual `nub . filter ((>0).snd)` pass, drop any slot whose advertised range (`offset + size`) extends past the end of the file.
- Sort the surviving slots by offset so that the monotonic `skipToOffset` walks forward correctly even for files whose mipmap table was not written in offset order.

Both checks are spec-faithful: the BLP1 spec says unused slots must be zero, so treating a slot that points into nowhere as "already unused" is just being lenient about malformed garbage. Sorting by offset is a no-op on conformant files.

Verified on 13 previously-failing samples; no regressions on the existing sample set.