### PR TITLE
Re-route mislabeled UncompressedWithAlpha BLPs

### DIFF
--- a/src/Codec/Picture/Blp/Internal/Parser.hs
+++ b/src/Codec/Picture/Blp/Internal/Parser.hs
@@ -39,9 +39,26 @@ blpParser = do
   blpMipMapOffset <- replicateM 16 dword <?> "mipmaps offsets"
   blpMipMapSize <- replicateM 16 dword <?> "mipmaps sizes"
   let mipMapsInfo = nub . filter ((> 0) . snd) $ blpMipMapOffset `zip` blpMipMapSize
+  -- Some writing tools set `pictureType` to `UncompressedWithAlpha` on
+  -- files whose mipmap 0 is actually only large enough for a single
+  -- index plane (w*h bytes) rather than indices + alpha (2*w*h bytes).
+  -- Trust the physical size over the picture-type byte and decode those
+  -- files via the without-alpha path instead of crashing on a half-read
+  -- index list.
+  let pixels0 :: Integer
+      pixels0 = fromIntegral blpWidth * fromIntegral blpHeight
+      mipZeroSize = case mipMapsInfo of
+        ((_, s):_) -> fromIntegral s :: Integer
+        []         -> 0
+      mislabeledAsAlpha =
+        blpPictureType == UncompressedWithAlpha &&
+        pixels0 > 0 &&
+        mipZeroSize == pixels0
+      effectivePictureType =
+        if mislabeledAsAlpha then UncompressedWithoutAlpha else blpPictureType
   blpExt <- case blpCompression of
     BlpCompressionJPEG -> blpJpegParser mipMapsInfo
-    BlpCompressionUncompressed -> case blpPictureType of
+    BlpCompressionUncompressed -> case effectivePictureType of
       JPEGType -> fail "JPEG type with Uncompressed type mix"
       UncompressedWithAlpha -> blpUncompressed1Parser mipMapsInfo
       UncompressedWithoutAlpha -> blpUncompressed2Parser mipMapsInfo


### PR DESCRIPTION
## What this fixes

Some writing tools set `pictureType = UncompressedWithAlpha` on files whose mipmap 0 is actually only large enough for a single index plane (`w*h` bytes) rather than indices + alpha (`2*w*h` bytes). Before this change the decoder followed the `pictureType` byte blindly, the parser happily halved the size into fake `indexList` / `alphaList` buffers of `w*h/2` bytes each, and then `generateImage` crashed with an unhandled `BS.index` out-of-bounds exception the moment it tried to read a pixel at or beyond offset `w*h/2`.

I have 7 such samples (64x64 and 32x32 BLPs produced by map tools) all with:

- `compression = 1`
- `pictureType = 4` (`UncompressedWithAlpha`)
- mipmap 0 size = `w*h`, not `2*w*h`

## What the change does

Trust the physical mipmap size over the `pictureType` byte: if the advertised picture type is `UncompressedWithAlpha` but mipmap 0 only contains `w*h` bytes, treat the file as `UncompressedWithoutAlpha` and decode via `blpUncompressed2Parser`. The size field is authoritative because it is the only value that has to be consistent with the file on disk. Normal uncompressed1 files (`size == 2*w*h`) are unaffected.

Verified on the 7 previously-crashing samples.