### PR TITLE
Decode JPEG tail mipmaps lazily so a corrupt tail cannot poison mipmap 0

### DIFF
--- a/src/Codec/Picture/Blp.hs
+++ b/src/Codec/Picture/Blp.hs
@@ -19,6 +19,8 @@ import Data.Monoid
 import Data.Word
 import TextShow.Debug.Trace
 
+import Data.Maybe (mapMaybe)
+
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Vector as V
@@ -50,8 +52,18 @@ decodeBlpMipmaps bs = do
   case blpExt $ traceTextShowId blp of
     BlpJpeg {..} -> do
       let jpegs = (blpJpegHeader <>) `fmap` blpJpegData
-      mips <- mapM decodeJpeg jpegs
-      return $ toPngRepresentable <$> mips
+      case jpegs of
+        [] -> Left "No JPEG mipmap data in BLP"
+        (j0:js) -> do
+          -- Mipmap 0 is the full-resolution image; single-image callers
+          -- (`decodeBlp`) only ever take `head` of the result. Decoding it
+          -- strictly means a failure here still fails the whole file as
+          -- before. Tail mipmaps are produced lazily by mapMaybe, so a
+          -- corrupt tail can no longer poison the main image via mapM's
+          -- short-circuit in Either.
+          mip0 <- decodeJpeg j0
+          let lazyTail = mapMaybe (either (const Nothing) Just . decodeJpeg) js
+          Right $ toPngRepresentable <$> (mip0 : lazyTail)
 
     BlpUncompressed1 {..} -> do
       let mkImage mip = ImageRGBA8 $ generateImage (gen mip) (fromIntegral $ blpWidth blp) (fromIntegral $ blpHeight blp)


### PR DESCRIPTION
## What this fixes

`decodeBlpMipmaps` currently runs `decodeJpeg` through `mapM` in the `Either` monad, so a single malformed tail mipmap short-circuits the whole parse and the caller loses the perfectly valid mipmap 0 along with it. Single-image callers (`readBlp` / `decodeBlp`) already take `head` of the result list, so they are paying for tail mipmaps that they never look at.

I have 10 real-world BLP1 files where mipmap 0 decodes cleanly but a tail mipmap is truncated; previously they all failed with `not enough bytes` bubbled up from the JuicyPixels JPEG decoder, even though the caller only wanted mipmap 0.

## What the change does

- Decode mipmap 0 strictly (its failure still fails the whole file, same as before).
- Produce the tail via `mapMaybe`, dropping any mipmap whose decode returned `Left`.
- Because the tail list is built lazily, single-image callers never force the decoder on a broken tail mipmap, and callers that do consume the full mipmap list simply see fewer entries when the input is partially corrupt.

No change in behaviour for well-formed files.

Verified on 10 previously-failing samples.