### PR TITLE
Accept BLP1 picture type 0 (untyped UncompressedWithAlpha variant)

### DIFF
--- a/src/Codec/Picture/Blp/Internal/Parser.hs
+++ b/src/Codec/Picture/Blp/Internal/Parser.hs
@@ -80,6 +80,7 @@ pictureTypeParser :: Parser BlpPictureType
 pictureTypeParser = (<?> "picture type") $ do
   i <- dword
   case i of
+    0 -> return UncompressedWithAlpha
     2 -> return JPEGType
     3 -> return UncompressedWithAlpha
     4 -> return UncompressedWithAlpha


### PR DESCRIPTION
## Summary

A subset of community-tooled BLP1 files write picture type **0** instead of the canonical 3/4 for an `UncompressedWithAlpha` image. Across a corpus of 2,797 failing BLPs, **214** files fail solely because of this — in every one of them `compression == 1` (uncompressed), the alpha flag bit is set, and mipmap 0 is exactly `2*w*h` bytes (i.e. they are valid `UncompressedWithAlpha` files with a non-canonical type byte).

`pictureTypeParser` is the only place that needs to change: map `0` to `UncompressedWithAlpha`. The existing `mislabeledAsAlpha` heuristic in `blpParser` (introduced in #8) already reclassifies an alpha-typed file whose mip0 is only `w*h` bytes as `UncompressedWithoutAlpha`, so the size-based fallback covers the rare case where a type-0 file is actually without alpha. For the JPEG branch the picture type is ignored entirely.

## Test plan

- [x] All 214 picture-type-0 files in the failing corpus now convert to PNG (214/214 success).
- [x] Existing pass-suite in `samples/new` still passes (30/30, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)